### PR TITLE
Support underscore in numbers

### DIFF
--- a/internal/lexer.go
+++ b/internal/lexer.go
@@ -96,7 +96,9 @@ func (l *Lexer) Lex(lval *yySymType) int {
 			hexVal, err = strconv.ParseUint(hex, 16, BitSizeOfInt)
 			tokenInfo.value = int(hexVal)
 		} else {
-			tokenInfo.value, err = strconv.Atoi(lit)
+			var n int64
+			n, err = strconv.ParseInt(lit, 0, BitSizeOfInt)
+			tokenInfo.value = int(n)
 		}
 		if err != nil {
 			l.Perrorf(pos, "parse error: cannot parse integer")


### PR DESCRIPTION
A while back Go added underscores to the syntax of numbers (for example 3_000). The package go/scanner automatically supports this but strconv.Atoi does not, resulting in an error when they are used. The goval documentation doesn't specify the syntax of its numbers but I think it would be useful if it did support underscores, for the same reasons they were added to Go.