### PR TITLE
fix: wrong comparison example result in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -307,7 +307,7 @@ Examples:
 
 ```
 3 <-4        // false
-45 > 3.4     // false
+45 > 3.4     // true
 -4 <= -1     // true
 3.5 >= 3.5   // true
 ```


### PR DESCRIPTION
I was reading the README file to see how operators work and noticed this comparison operator example's result is not correct. I tried to evaluate the example expression and it returned `true` so I decided to update the README and fix this example.